### PR TITLE
fix not working with @strapi/plugin-users-permissions 4.1.8 and above

### DIFF
--- a/permissions.js
+++ b/permissions.js
@@ -27,7 +27,7 @@ class Permissions {
 
     strapi.log.info("[Permissions] 🚀 Setting up permissions...");
 
-    let roles = await strapi.service("plugin::users-permissions.role").find();
+    let roles = await strapi.service("plugin::users-permissions.role").getRoles();
 
     // Add roles that are set in config but not in strapi
     for (const configRole of Object.keys(strapi.config.permissions)) {
@@ -47,7 +47,7 @@ class Permissions {
         .createRole(roleToAdd);
     }
 
-    roles = await strapi.service("plugin::users-permissions.role").find();
+    roles = await strapi.service("plugin::users-permissions.role").getRoles();
 
     for (let role of roles) {
       if (!role || role.id === null) {
@@ -56,7 +56,7 @@ class Permissions {
 
       role = await strapi
         .service("plugin::users-permissions.role")
-        .findOne(role.id, []);
+        .getRole(role.id);
 
       // Disable all current permissions
       const existingPermissionKeys = Object.keys(role.permissions);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

fix not working with `@strapi/plugin-users-permissions` version `4.1.8` and above: 
- `strapi.service("plugin::users-permissions.role").find` is not a function
- `strapi.service("plugin::users-permissions.role").findOne` is not a function


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
