### PR TITLE
Feat/typescript support strapi change

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Enable in `config/plugins.js`:
 ```json
 {
   "permissions": {
-    "enabled": true,
-    "resolve": "@gravitybv/strapi-plugin-permissions"
+    "enabled": true
   }
 }
 ```
@@ -33,6 +32,23 @@ Use `api::` to target one of your own controllers.
 
 When only specifying the prefix and entity name, without targeting a controller (e.g. `api::restaurant` or `plugin::users-permissions`), the plugin will set the permissions for all of the controllers in that entity.
 To target a specific controller, please use: `api::restaurant.restaurant`, or `plugin::users-permissions.auth`.
+
+### Typescript
+
+When using in a typescript project add a config to the plugin config:
+
+`config/plugins.js`
+
+```json
+{
+  "permissions": {
+    "enabled": true,
+    "config": {
+      "typescript": true
+    }
+  }
+}
+```
 
 ## License
 

--- a/default-config.ts
+++ b/default-config.ts
@@ -1,0 +1,23 @@
+export default {
+  public: {
+    description: "Default role given to unauthenticated user.",
+    permissions: {
+      "plugin::users-permissions.auth": [
+        "callback",
+        "connect",
+        "emailConfirmation",
+        "forgotPassword",
+        "register",
+        "resetPassword",
+        "sendEmailConfirmation",
+      ],
+    },
+  },
+  authenticated: {
+    description: "Default role given to authenticated user.",
+    permissions: {
+      "plugin::users-permissions.auth": ["callback", "connect"],
+      "plugin::users-permissions.user": ["me"],
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gravitybv/strapi-plugin-permissions",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Strapi plugin that handles permissions through a config file.",
   "main": "strapi-server.js",
   "scripts": {

--- a/permissions.js
+++ b/permissions.js
@@ -137,9 +137,9 @@ class Permissions {
   }
 
   async createPermissionsFile(typescript = false) {
-    const targetFilename = `${strapi.dirs.config}/permissions.${
-      typescript ? "ts" : "js"
-    }`;
+    const targetFilename = `${
+      strapi.dirs.config || strapi.dirs.app.config
+    }/permissions.${typescript ? "ts" : "js"}`;
 
     try {
       await fs.stat(targetFilename);

--- a/permissions.js
+++ b/permissions.js
@@ -12,14 +12,18 @@ class Permissions {
       return;
     }
 
+    const pluginConfig = strapi.config.get("plugin.permissions");
+
     if (!strapi.config.permissions) {
       strapi.log.info("[Permissions] 🚀 Creating permissions file...");
-      await this.createPermissionsFile();
+      await this.createPermissionsFile(pluginConfig.typescript);
 
       // Strapi is now auto restarting... if not, schedule a 'kill'
       setTimeout(() => {
         strapi.log.info(
-          "[Permissions] 🚀 Created config/permissions.js. Please restart Strapi manually."
+          `[Permissions] 🚀 Created config/permissions.${
+            pluginConfig.typescript ? "ts" : "js"
+          }. Please restart Strapi manually.`
         );
         process.exit(1);
       }, 200);
@@ -132,8 +136,10 @@ class Permissions {
     strapi.log.info("[Permissions] 🚀 All permissions set.");
   }
 
-  async createPermissionsFile() {
-    const targetFilename = `${strapi.dirs.config}/permissions.js`;
+  async createPermissionsFile(typescript = false) {
+    const targetFilename = `${strapi.dirs.config}/permissions.${
+      typescript ? "ts" : "js"
+    }`;
 
     try {
       await fs.stat(targetFilename);
@@ -142,7 +148,10 @@ class Permissions {
         return;
       }
 
-      await fs.copyFile(`${__dirname}/default-config.js`, targetFilename);
+      await fs.copyFile(
+        `${__dirname}/default-config.${typescript ? "ts" : "js"}`,
+        targetFilename
+      );
     }
   }
 }


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Typescript support:
Added optional typescript option to config, when set a typescript template is used to implement the default config.

Strapi dir change:
In newer versions of strapi the dir reference has be moved to strapi.dirs.app.config instead of strapi.dirs.config. This fixes the reference.

Plugin config documentation change:
Removed 'resolve' parameter in suggested config. This is only needed in development of the plugin itself. Strapi registers plugin based on the package json. (strapi: {kind: 'plugin'})


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ NA ] I have added tests to cover my changes (if not applicable, please state why) 
There are no tests in package.
