### PR TITLE
fix: add multiple retries (and exception) to bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Use `api::` to target one of your own controllers.
 When only specifying the prefix and entity name, without targeting a controller (e.g. `api::restaurant` or `plugin::users-permissions`), the plugin will set the permissions for all of the controllers in that entity.
 To target a specific controller, please use: `api::restaurant.restaurant`, or `plugin::users-permissions.auth`.
 
-### Typescript
+### Configuration
+
+#### Typescript
 
 When using in a typescript project add a config to the plugin config:
 
@@ -61,6 +63,29 @@ When using in a typescript project add a config to the plugin config:
 	}
 }
 ```
+
+#### Advanced Options
+
+You can configure the retry behavior when waiting for Strapi to load:
+
+`config/plugins.js`
+
+```json
+{
+	"permissions": {
+		"enabled": true,
+		"config": {
+			"maxRetries": 50,
+			"initialDelay": 200
+		}
+	}
+}
+```
+
+- **maxRetries** (default: `50`): Maximum number of retry attempts before timing out
+- **initialDelay** (default: `200`): Delay in milliseconds between retry attempts
+
+The default configuration allows for a total wait time of 10 seconds (50 retries × 200ms)
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gravitybv/strapi-plugin-permissions",
-  "version": "1.0.1",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gravitybv/strapi-plugin-permissions",
-      "version": "1.0.1",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gravitybv/strapi-plugin-permissions",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Strapi plugin that handles permissions through a config file.",
   "main": "strapi-server.js",
   "scripts": {

--- a/permissions.js
+++ b/permissions.js
@@ -8,13 +8,27 @@ const convertRoleNameToRoleType = (roleName) => {
 };
 
 class Permissions {
-  async setup() {
+  async setup(retries = 0) {
+    const MAX_RETRIES = 5;
+    
     if (!strapi.isLoaded) {
-      setTimeout(() => {
-        this.setup();
-      }, 200);
-      return;
+      if (retries >= MAX_RETRIES) {
+        strapi.log.error(
+          `[Permissions] ❌ Timeout: Strapi not loaded after ${(MAX_RETRIES * 200) / 1000}s. Permissions not set!`
+        );
+        return;
+      }
+      
+      // Wait 200ms and retry
+      return new Promise((resolve) => {
+        setTimeout(async () => {
+          await this.setup(retries + 1);
+          resolve();
+        }, 200);
+      });
     }
+    
+    strapi.log.info("[Permissions] 🔄 Starting permissions setup...");
 
     const pluginConfig = strapi.config.get("plugin.permissions");
 

--- a/permissions.js
+++ b/permissions.js
@@ -9,28 +9,28 @@ const convertRoleNameToRoleType = (roleName) => {
 
 class Permissions {
   async setup(retries = 0) {
-    const MAX_RETRIES = 50; // Max 10 seconds (50 * 200ms)
+    const pluginConfig = strapi.config.get("plugin.permissions");
+    const MAX_RETRIES = pluginConfig?.maxRetries ?? 50;
+    const INITIAL_DELAY = pluginConfig?.initialDelay ?? 200;
     
     if (!strapi.isLoaded) {
       if (retries >= MAX_RETRIES) {
         strapi.log.error(
-          `[Permissions] ❌ Timeout: Strapi not loaded after ${(MAX_RETRIES * 200) / 1000}s. Permissions not set!`
+          `[Permissions] ❌ Timeout: Strapi not loaded after ${(MAX_RETRIES * INITIAL_DELAY) / 1000}s. Permissions not set!`
         );
         return;
       }
       
-      // Wait 200ms and retry
+      // Wait and retry
       return new Promise((resolve) => {
         setTimeout(async () => {
           await this.setup(retries + 1);
           resolve();
-        }, 200);
+        }, INITIAL_DELAY);
       });
     }
     
     strapi.log.info("[Permissions] 🔄 Starting permissions setup...");
-
-    const pluginConfig = strapi.config.get("plugin.permissions");
 
     if (!strapi.config.permissions) {
       strapi.log.info("[Permissions] 🚀 Creating permissions file...");

--- a/permissions.js
+++ b/permissions.js
@@ -29,8 +29,6 @@ class Permissions {
         }, INITIAL_DELAY);
       });
     }
-    
-    strapi.log.info("[Permissions] 🔄 Starting permissions setup...");
 
     if (!strapi.config.permissions) {
       strapi.log.info("[Permissions] 🚀 Creating permissions file...");
@@ -120,11 +118,6 @@ class Permissions {
         const moduleParts = permissionKey.split("::");
         const moduleName = _.last(moduleParts) || permissionKey;
 
-        strapi.log.debug(`[Permissions] Processing key: ${permissionKey}`);
-        strapi.log.debug(`[Permissions]   - keyParts: ${JSON.stringify(keyParts)}`);
-        strapi.log.debug(`[Permissions]   - key: ${key}`);
-        strapi.log.debug(`[Permissions]   - moduleName: ${moduleName}`);
-
         const targetControllers =
           _.get(role.permissions[key], "controllers", null) || null;
         if (!targetControllers) {
@@ -175,7 +168,7 @@ class Permissions {
           for (const permission of permissionConfig[permissionKey]) {
             if (_.has(controller, permission)) {
               _.set(controller, `${permission}.enabled`, true);
-              strapi.log.info(
+              strapi.log.debug(
                 `[Permissions]   ✅ Enabled '${permission}' for '${permissionKey}'`
               );
             } else {

--- a/permissions.js
+++ b/permissions.js
@@ -9,7 +9,7 @@ const convertRoleNameToRoleType = (roleName) => {
 
 class Permissions {
   async setup(retries = 0) {
-    const MAX_RETRIES = 5;
+    const MAX_RETRIES = 50; // Max 10 seconds (50 * 200ms)
     
     if (!strapi.isLoaded) {
       if (retries >= MAX_RETRIES) {
@@ -120,31 +120,67 @@ class Permissions {
         const moduleParts = permissionKey.split("::");
         const moduleName = _.last(moduleParts) || permissionKey;
 
+        strapi.log.debug(`[Permissions] Processing key: ${permissionKey}`);
+        strapi.log.debug(`[Permissions]   - keyParts: ${JSON.stringify(keyParts)}`);
+        strapi.log.debug(`[Permissions]   - key: ${key}`);
+        strapi.log.debug(`[Permissions]   - moduleName: ${moduleName}`);
+
         const targetControllers =
           _.get(role.permissions[key], "controllers", null) || null;
         if (!targetControllers) {
           strapi.log.error(
             `[Permissions] Controller '${key}' not found! Skipping...`
           );
+          strapi.log.debug(
+            `[Permissions]   Available keys in role.permissions: ${JSON.stringify(Object.keys(role.permissions))}`
+          );
           continue;
         }
 
+        strapi.log.debug(
+          `[Permissions]   - Available controllers: ${JSON.stringify(Object.keys(targetControllers))}`
+        );
+
         const controllers = [];
         if (keyParts.length > 1) {
-          controllers.push(targetControllers[keyParts[1]]);
+          strapi.log.debug(`[Permissions]   - Using keyParts[1]: ${keyParts[1]}`);
+          const controller = targetControllers[keyParts[1]];
+          if (controller) {
+            controllers.push(controller);
+          } else {
+            strapi.log.warn(
+              `[Permissions]   - Controller '${keyParts[1]}' not found in targetControllers!`
+            );
+          }
         } else if (_.has(targetControllers, moduleName)) {
+          strapi.log.debug(`[Permissions]   - Using moduleName: ${moduleName}`);
           controllers.push(targetControllers[moduleName]);
         } else {
+          strapi.log.debug(`[Permissions]   - Using all controllers`);
           controllers.push(targetControllers);
         }
 
         for (const controller of controllers) {
+          if (!controller) {
+            strapi.log.warn(
+              `[Permissions]   - Controller is null/undefined for '${permissionKey}', skipping...`
+            );
+            continue;
+          }
+
+          strapi.log.debug(
+            `[Permissions]   - Controller actions: ${JSON.stringify(Object.keys(controller))}`
+          );
+
           for (const permission of permissionConfig[permissionKey]) {
             if (_.has(controller, permission)) {
               _.set(controller, `${permission}.enabled`, true);
+              strapi.log.info(
+                `[Permissions]   ✅ Enabled '${permission}' for '${permissionKey}'`
+              );
             } else {
               strapi.log.error(
-                `[Permissions] Permission '${permission}' not found for '${permissionKey}'. Skipping...`
+                `[Permissions]   ❌ Permission '${permission}' not found for '${permissionKey}'. Available: ${JSON.stringify(Object.keys(controller))}`
               );
             }
           }
@@ -156,7 +192,7 @@ class Permissions {
         .updateRole(role.id, role);
     }
 
-    strapi.log.info("[Permissions] 🚀 All permissions set.");
+    strapi.log.info("[Permissions] 🚀 All permissions set!");
   }
 
   async createPermissionsFile(typescript = false) {

--- a/strapi-server.js
+++ b/strapi-server.js
@@ -10,6 +10,6 @@ module.exports = {
     }
     
     const permissions = new Permissions(strapi);
-    return permissions.setup();
+    permissions.setup();
   }
 };

--- a/strapi-server.js
+++ b/strapi-server.js
@@ -10,6 +10,6 @@ module.exports = {
     }
     
     const permissions = new Permissions(strapi);
-    permissions.setup();
+    return permissions.setup();
   }
 };


### PR DESCRIPTION
Detected an issue on the bootstrap where permissions would not properly set.
- increased max setup script runs to max 5 retries instead of 1
- make retry and delay configurable